### PR TITLE
Install graphviz package with xhprof-gui

### DIFF
--- a/recipes/xhgui.rb
+++ b/recipes/xhgui.rb
@@ -89,4 +89,7 @@ web_app node['xhprof']['hostname'] do
   docroot "#{node['xhprof']['install_path']}/xhprof_html"
 end
 
+# Install Graphviz for use with xhprof-gui graphs.
+package "graphviz"
+
 log " You can now access XHGui at #{node['xhprof']['hostname']} #{node['fqdn']}"


### PR DESCRIPTION
Add package installation for graphviz for use with xhprof-gui, since I end up installing it manually every time anyway.
