### PR TITLE
The gui recipe doesn't creates the correct database.

### DIFF
--- a/recipes/xhgui.rb
+++ b/recipes/xhgui.rb
@@ -36,7 +36,7 @@ mysql_connection_info = {
   :password => node['mysql']['server_root_password']
 }
 
-mysql_database "xhprof" do
+mysql_database node['xhprof']['db']['database'] do
   connection (mysql_connection_info)
   action :create
 end


### PR DESCRIPTION
When using a non-default database name, the chef-xhprof-gui::xhgui recipe won't
create that database since "xhprof" is hardcoded as database name.

ref: #9